### PR TITLE
Fixed swapchain present-wait semaphore reuse

### DIFF
--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -1415,6 +1415,8 @@ lvk::TextureHandle lvk::VulkanSwapchain::getCurrentTexture() {
       if (presentFence_[currentImageIndex_]) {
         VK_ASSERT(vkWaitForFences(device_, 1, &presentFence_[currentImageIndex_], VK_TRUE, UINT64_MAX));
         VK_ASSERT(vkResetFences(device_, 1, &presentFence_[currentImageIndex_]));
+        // present done; drop the reuse guard (its fence was just reset)
+        ctx_.immediate_->setLastPresentSemaphore(VK_NULL_HANDLE, VK_NULL_HANDLE);
       }
     } else {
       // without VK_KHR_swapchain_maintenance1: use acquire fences to synchronize semaphore reuse
@@ -1486,6 +1488,9 @@ lvk::Result lvk::VulkanSwapchain::present(VkSemaphore waitSemaphore) {
     VK_ASSERT(r);
   }
   LVK_PROFILER_ZONE_END();
+
+  // let acquire() gate reuse of this command buffer's slot until the present has consumed its wait semaphore
+  ctx_.immediate_->setLastPresentSemaphore(waitSemaphore, presentFence_[currentImageIndex_]);
 
   // drop the previous present mode so we don't set it again in the next `present()` call if the present mode is not switched at runtime
   presentFenceInfo_.pNext = nullptr;
@@ -1613,6 +1618,13 @@ const lvk::VulkanImmediateCommands::CommandBufferWrapper& lvk::VulkanImmediateCo
   LVK_ASSERT_MSG(numAvailableCommandBuffers_, "No available command buffers");
   LVK_ASSERT_MSG(current, "No available command buffers");
   LVK_ASSERT(current->cmdBufAllocated_ != VK_NULL_HANDLE);
+
+  // wait for a pending present still using this slot's semaphore before reusing it (VUID-vkQueueSubmit2-semaphore-03868)
+  if (current->semaphore_ == lastPresentSemaphore_ && lastPresentFence_) {
+    VK_ASSERT(vkWaitForFences(device_, 1, &lastPresentFence_, VK_TRUE, UINT64_MAX));
+    lastPresentSemaphore_ = VK_NULL_HANDLE;
+    lastPresentFence_ = VK_NULL_HANDLE;
+  }
 
   current->handle_.submitId_ = submitCounter_;
   numAvailableCommandBuffers_--;
@@ -1845,6 +1857,11 @@ void lvk::VulkanImmediateCommands::signalSemaphore(VkSemaphore semaphore, uint64
 
 VkSemaphore lvk::VulkanImmediateCommands::acquireLastSubmitSemaphore() {
   return std::exchange(lastSubmitSemaphore_.semaphore, VK_NULL_HANDLE);
+}
+
+void lvk::VulkanImmediateCommands::setLastPresentSemaphore(VkSemaphore semaphore, VkFence presentFence) {
+  lastPresentSemaphore_ = semaphore;
+  lastPresentFence_ = presentFence;
 }
 
 VkFence lvk::VulkanImmediateCommands::getVkFence(lvk::SubmitHandle handle) const {
@@ -7690,6 +7707,8 @@ lvk::Result lvk::VulkanContext::initSwapchain(uint32_t width, uint32_t height) {
     // destroy the old swapchain first
     // TODO: replace with VK_EXT_swapchain_maintenance1
     VK_ASSERT(vkDeviceWaitIdle(vkDevice_));
+    // the guard fence belongs to the swapchain we are about to destroy
+    immediate_->setLastPresentSemaphore(VK_NULL_HANDLE, VK_NULL_HANDLE);
     swapchain_ = nullptr;
     vkDestroySemaphore(vkDevice_, timelineSemaphore_, nullptr);
   }

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -197,6 +197,7 @@ class VulkanImmediateCommands final {
   void waitSemaphore(VkSemaphore semaphore);
   void signalSemaphore(VkSemaphore semaphore, uint64_t signalValue);
   VkSemaphore acquireLastSubmitSemaphore();
+  void setLastPresentSemaphore(VkSemaphore semaphore, VkFence presentFence);
   VkFence getVkFence(SubmitHandle handle) const;
   SubmitHandle getLastSubmitHandle() const;
   SubmitHandle getNextSubmitHandle() const;
@@ -223,6 +224,8 @@ class VulkanImmediateCommands final {
                                           .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT}; // extra "wait" semaphore
   VkSemaphoreSubmitInfo signalSemaphore_ = {.sType = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
                                             .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT}; // extra "signal" semaphore
+  VkSemaphore lastPresentSemaphore_ = VK_NULL_HANDLE; // present-wait semaphore of the last vkQueuePresentKHR()
+  VkFence lastPresentFence_ = VK_NULL_HANDLE; // its present fence; acquire() waits it before reusing that slot
   uint32_t numAvailableCommandBuffers_ = kMaxCommandBuffers;
   uint32_t submitCounter_ = 1;
 };


### PR DESCRIPTION
## Summary

Fixes a validation error (`VUID-vkQueueSubmit2-semaphore-03868`) caused by reusing a swapchain present-wait semaphore before the presentation engine has consumed it.

The per-command-buffer semaphore signalled by `VulkanImmediateCommands::submit()` is handed to `vkQueuePresentKHR()` as the present-wait semaphore. However, command buffer slots are recycled based **only** on their execution fence. A later submit (e.g. a texture upload during async loading) could re-acquire the same slot and re-signal that semaphore *before* the presentation engine had consumed it — leaving the semaphore in an illegal state and tripping the validation layers.

## Changes

- `present()` now records the present-wait semaphore together with its `presentFence_` via a new `VulkanImmediateCommands::setLastPresentSemaphore()`.
- `acquire()` waits on that fence before reusing the matching command-buffer slot, so a pending present always finishes consuming the semaphore first.
- The reuse guard is cleared in:
  - `getCurrentTexture()` once the present fence has been waited (so we never block on an already-reset fence), and
  - `initSwapchain()` when the swapchain is recreated (the guard fence belongs to the swapchain being destroyed).

## Notes

- Cherry-picked from the `oit` branch (`d84eca2`).
- Self-contained: touches only `lvk/vulkan/VulkanClasses.{h,cpp}` and relies only on symbols already present on `main` (`presentFence_`, `CommandBufferWrapper::semaphore_`).
- No public API changes; the new method is internal to `VulkanImmediateCommands`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
